### PR TITLE
add resize check, update contract address, batch query calls

### DIFF
--- a/src/components/bondingCurveChart/bonding_curve_chart.tsx
+++ b/src/components/bondingCurveChart/bonding_curve_chart.tsx
@@ -81,9 +81,17 @@ export default function BondingCurveChart(props: IProps) {
             setChartParam(props.chartParam);
 
             const curChartParam = props.chartParam;
-            const resizeObserver = new ResizeObserver(entries => {
-                if (curChartParam && curChartParam.currentSupply) {
-                    buildGraph(curChartParam, true);
+            const previousSize = {
+                width: 0,
+                height: 0
+            }
+            const resizeObserver = new ResizeObserver(entries => {                
+                if(entries[0].contentRect.width != previousSize.width || entries[0].contentRect.height != previousSize.height){
+                    previousSize.width = entries[0].contentRect.width;
+                    previousSize.height = entries[0].contentRect.height;
+                    if (curChartParam && curChartParam.currentSupply) {
+                        buildGraph(curChartParam, true);
+                    }
                 }
             });           
     

--- a/src/components/dashboard/claim_lp_rewards.tsx
+++ b/src/components/dashboard/claim_lp_rewards.tsx
@@ -18,6 +18,7 @@ import { isAbleToSendTransaction } from '../../config/validation'
 
 type mintProps = {
   dashboardDataSet: any;
+  closeParentDialog: any;
 }
 
 export default function ClaimLpRewards(props: mintProps) {
@@ -25,6 +26,7 @@ export default function ClaimLpRewards(props: mintProps) {
   const [provider, setProvider] = useState<ethers.providers.Web3Provider | null>()
   const [ibcContractAddress, ] = useState<string>(contracts.tenderly.ibcContract)
   const {dashboardDataSet} = props
+  let closeParentDialog = props.closeParentDialog;
 
   const userClaimableLpRewards = BigNumber.from("userClaimableLpRewards" in dashboardDataSet ? dashboardDataSet.userClaimableLpRewards : '0')
   const userClaimableLpReserveRewards = BigNumber.from("userClaimableLpReserveRewards" in dashboardDataSet ? dashboardDataSet.userClaimableLpReserveRewards : '0')
@@ -104,6 +106,7 @@ export default function ClaimLpRewards(props: mintProps) {
 
         if (RewardClaimedDetails){
           description = `Received ${Number(formatUnits(RewardClaimedDetails[0], inverseTokenDecimals)).toFixed(4)} IBC and ${Number(formatEther(RewardClaimedDetails[1])).toFixed(4)} ETH`
+          closeParentDialog();
         }
       } 
 
@@ -117,7 +120,7 @@ export default function ClaimLpRewards(props: mintProps) {
         duration: 5000,
         isClosable: true
       })
-
+      
       console.log(result)
 
     } catch (error:any) {
@@ -143,8 +146,8 @@ export default function ClaimLpRewards(props: mintProps) {
     <>
       <Stack p='4'>
         <Text align="left" fontSize='sm'>YOU HAVE ACCRUED</Text>
-        <Text fontSize={'2xl'}>{`${IBC_rewards} IBC`}</Text>
-        <Text fontSize={'2xl'}>{`${ETH_rewards} ETH`}</Text>
+        <Text align="right" fontSize={'2xl'}>{`${IBC_rewards} IBC`}</Text>
+        <Text align="right" fontSize={'2xl'}>{`${ETH_rewards} ETH`}</Text>
         {
           isProcessing &&
           <DefaultSpinner />
@@ -154,7 +157,7 @@ export default function ClaimLpRewards(props: mintProps) {
           alignSelf={'center'}
           w='100%'
           onClick={sendTransaction}
-          isDisabled={!isAbleToSendTransaction(wallet, provider, Math.max(Number(IBC_rewards), Number(ETH_rewards)))}
+          isDisabled={!isAbleToSendTransaction(wallet, provider, Math.max(Number(IBC_rewards), Number(ETH_rewards))) || isProcessing}
           >
             Claim
           </Button>

--- a/src/components/dashboard/stake_ibc.tsx
+++ b/src/components/dashboard/stake_ibc.tsx
@@ -188,7 +188,7 @@ export default function StakeIbc(props: mintProps) {
           alignSelf={'center'}
           w='100%'
           onClick={sendTransaction}
-          isDisabled={!isAbleToSendTransaction(wallet, provider, amount)}>
+          isDisabled={!isAbleToSendTransaction(wallet, provider, amount) || isProcessing}>
         {
               userInverseTokenAllowance.gt(0) ? "Stake" : "Approve IBC"
         }

--- a/src/components/dashboard/unstake_ibc.tsx
+++ b/src/components/dashboard/unstake_ibc.tsx
@@ -152,7 +152,7 @@ export default function UnstakeIbc(props: mintProps) {
           alignSelf={'center'}
           w='100%'
           onClick={sendTransaction}
-          isDisabled={!isAbleToSendTransaction(wallet, provider, amount)}
+          isDisabled={!isAbleToSendTransaction(wallet, provider, amount) || isProcessing}
           >
             Unstake
           </Button>

--- a/src/config/contracts.ts
+++ b/src/config/contracts.ts
@@ -4,6 +4,6 @@ export const contracts = {
   tenderly:{
     uniswapV2Factory: "0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f",
     wethAddress: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-    ibcContract: "0x1d5133a1d3015194D991D14FE559EfB6b6692985"
+    ibcContract: "0x6f957b615182190dc13671cB4bA89Ad80a1D9A70"
   }
 }

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -83,7 +83,7 @@ export function Dashboard( props: dashboardProps ){
     }
   );
   const forceUpdate = React.useCallback(() => updateState({}), []);
-
+  
 
   useEffect(() => {
     const fetchIbcMetrics = async() => {
@@ -147,62 +147,160 @@ export function Dashboard( props: dashboardProps ){
         const abiCoder = ethers.utils.defaultAbiCoder
         
         //  user balance info
-        const ethBalance = await provider.getBalance(wallet.accounts[0].address)
+        // const ethBalance = await provider.getBalance(wallet.accounts[0].address)
 
-        // ibc contract state
+
+
+        // // ibc contract state
+        // const bondingCurveParamsQuery = composeQuery(ibcContractAddress, "curveParameters", [], [])
+        // const bondingCurveParamsBytes = await provider.call(bondingCurveParamsQuery)
+        // const bondingCurveParams = abiCoder.decode(["(uint256,uint256,uint256,uint256,uint256,int256,uint256)"], bondingCurveParamsBytes)
+
+        // const inverseTokenAddressQuery = composeQuery(ibcContractAddress, "inverseTokenAddress", [], [])
+        // const inverseTokenAddressBytes = await provider.call(inverseTokenAddressQuery)
+        // const inverseTokenAddress = abiCoder.decode(["address"], inverseTokenAddressBytes)[0]
+
+        // const feeQuery = composeQuery(ibcContractAddress, "feeConfig", [], [])
+        // const feeBytes = await provider.call(feeQuery)
+        // const fees = abiCoder.decode([`uint256[${actionTypes.length}]`, `uint256[${actionTypes.length}]`, `uint256[${actionTypes.length}]`], feeBytes)
+
+
+
+        // // lp token info
+        // const lpTokenDecimalsQuery = composeQuery(ibcContractAddress, "decimals", [], [])
+        // const lpTokenDecimalsBytes = await provider.call(lpTokenDecimalsQuery)
+        // const lpTokenDecimals = abiCoder.decode(["uint"], lpTokenDecimalsBytes)[0]
+
+        // const lpTokenSupplyQuery = composeQuery(ibcContractAddress, "totalSupply", [], [])
+        // const lpTokenSupplyBytes = await provider.call(lpTokenSupplyQuery)
+        // const lpTokenSupply = abiCoder.decode(["uint"], lpTokenSupplyBytes)[0]
+
+        // const userLpTokenBalanceQuery = composeQuery(ibcContractAddress, "balanceOf", ["address"], [wallet.accounts[0].address])
+        // const userLpTokenBalanceBytes = await provider.call(userLpTokenBalanceQuery)
+        // const userLpTokenBalance = abiCoder.decode(["uint"], userLpTokenBalanceBytes)[0]
+
+        // // lp approval state
+        // const userLpTokenAllowanceQuery = composeQuery(ibcContractAddress, "allowance", ["address", "address"], [wallet.accounts[0].address, ibcContractAddress])
+        // const userLpTokenAllowanceBytes = await provider.call(userLpTokenAllowanceQuery)
+        // const userLpTokenAllowance = abiCoder.decode(["uint"], userLpTokenAllowanceBytes)[0]
+
+        // // fetch rewards data
+        // const userClaimableRewardsQuery = composeQuery(ibcContractAddress, "rewardOf", ["address"], [wallet.accounts[0].address])
+        // const userClaimableRewardsBytes = await provider.call(userClaimableRewardsQuery)
+        // const userClaimableRewards = abiCoder.decode(["uint256", "uint256", "uint256", "uint256"], userClaimableRewardsBytes)
+
+        // // fetch staking balance
+        // const userStakingBalanceQuery = composeQuery(ibcContractAddress, "stakingBalanceOf", ["address"], [wallet.accounts[0].address])
+        // const userStakingBalanceBytes = await provider.call(userStakingBalanceQuery)
+        // const userStakingBalance = abiCoder.decode(["uint256"], userStakingBalanceBytes)[0]
+
+
+
+
+
+
+        // // ibc token info
+        // const inverseTokenDecimalsQuery = composeQuery(inverseTokenAddress, "decimals", [], [])
+        // const inverseTokenDecimalsBytes = await provider.call(inverseTokenDecimalsQuery)
+        // const inverseTokenDecimals = abiCoder.decode(["uint"], inverseTokenDecimalsBytes)[0]
+
+        // const userInverseTokenBalanceQuery = composeQuery(inverseTokenAddress, "balanceOf", ["address"], [wallet.accounts[0].address])
+        // const userInverseTokenBalanceBytes = await provider.call(userInverseTokenBalanceQuery)
+        // const userInverseTokenBalance = abiCoder.decode(["uint"], userInverseTokenBalanceBytes)[0]
+
+        // // ibc approval state
+        // const userInverseTokenAllowanceQuery = composeQuery(inverseTokenAddress, "allowance", ["address", "address"], [wallet.accounts[0].address, ibcContractAddress])
+        // const userInverseTokenAllowanceBytes = await provider.call(userInverseTokenAllowanceQuery)
+        // const userInverseTokenAllowance = abiCoder.decode(["uint"], userInverseTokenAllowanceBytes)[0]
+
         const bondingCurveParamsQuery = composeQuery(ibcContractAddress, "curveParameters", [], [])
-        const bondingCurveParamsBytes = await provider.call(bondingCurveParamsQuery)
+        const inverseTokenAddressQuery = composeQuery(ibcContractAddress, "inverseTokenAddress", [], [])
+        const feeQuery = composeQuery(ibcContractAddress, "feeConfig", [], [])
+        const lpTokenDecimalsQuery = composeQuery(ibcContractAddress, "decimals", [], [])
+        const lpTokenSupplyQuery = composeQuery(ibcContractAddress, "totalSupply", [], [])
+        const userLpTokenBalanceQuery = composeQuery(ibcContractAddress, "balanceOf", ["address"], [wallet.accounts[0].address])
+        const userLpTokenAllowanceQuery = composeQuery(ibcContractAddress, "allowance", ["address", "address"], [wallet.accounts[0].address, ibcContractAddress])
+        const userClaimableRewardsQuery = composeQuery(ibcContractAddress, "rewardOf", ["address"], [wallet.accounts[0].address])
+        const userStakingBalanceQuery = composeQuery(ibcContractAddress, "stakingBalanceOf", ["address"], [wallet.accounts[0].address])
+
+        const queryResults = await Promise.all([
+          provider.getBalance(wallet.accounts[0].address),
+          provider.call(bondingCurveParamsQuery),
+          provider.call(inverseTokenAddressQuery),
+          provider.call(feeQuery),
+          provider.call(lpTokenDecimalsQuery),
+          provider.call(lpTokenSupplyQuery),
+          provider.call(userLpTokenBalanceQuery),
+          provider.call(userLpTokenAllowanceQuery),
+          provider.call(userClaimableRewardsQuery),
+          provider.call(userStakingBalanceQuery)
+        ]);
+
+        const ethBalance = queryResults[0];
+        // ibc contract state
+        
+        const bondingCurveParamsBytes = queryResults[1];
         const bondingCurveParams = abiCoder.decode(["(uint256,uint256,uint256,uint256,uint256,int256,uint256)"], bondingCurveParamsBytes)
 
-        const inverseTokenAddressQuery = composeQuery(ibcContractAddress, "inverseTokenAddress", [], [])
-        const inverseTokenAddressBytes = await provider.call(inverseTokenAddressQuery)
+        
+        const inverseTokenAddressBytes = queryResults[2];
         const inverseTokenAddress = abiCoder.decode(["address"], inverseTokenAddressBytes)[0]
 
-        const feeQuery = composeQuery(ibcContractAddress, "feeConfig", [], [])
-        const feeBytes = await provider.call(feeQuery)
+        
+        const feeBytes = queryResults[3];
         const fees = abiCoder.decode([`uint256[${actionTypes.length}]`, `uint256[${actionTypes.length}]`, `uint256[${actionTypes.length}]`], feeBytes)
 
-        // ibc token info
-        const inverseTokenDecimalsQuery = composeQuery(inverseTokenAddress, "decimals", [], [])
-        const inverseTokenDecimalsBytes = await provider.call(inverseTokenDecimalsQuery)
-        const inverseTokenDecimals = abiCoder.decode(["uint"], inverseTokenDecimalsBytes)[0]
 
-        const userInverseTokenBalanceQuery = composeQuery(inverseTokenAddress, "balanceOf", ["address"], [wallet.accounts[0].address])
-        const userInverseTokenBalanceBytes = await provider.call(userInverseTokenBalanceQuery)
-        const userInverseTokenBalance = abiCoder.decode(["uint"], userInverseTokenBalanceBytes)[0]
-
-        // ibc approval state
-        const userInverseTokenAllowanceQuery = composeQuery(inverseTokenAddress, "allowance", ["address", "address"], [wallet.accounts[0].address, ibcContractAddress])
-        const userInverseTokenAllowanceBytes = await provider.call(userInverseTokenAllowanceQuery)
-        const userInverseTokenAllowance = abiCoder.decode(["uint"], userInverseTokenAllowanceBytes)[0]
 
         // lp token info
-        const lpTokenDecimalsQuery = composeQuery(ibcContractAddress, "decimals", [], [])
-        const lpTokenDecimalsBytes = await provider.call(lpTokenDecimalsQuery)
+        
+        const lpTokenDecimalsBytes = queryResults[4];
         const lpTokenDecimals = abiCoder.decode(["uint"], lpTokenDecimalsBytes)[0]
 
-        const lpTokenSupplyQuery = composeQuery(ibcContractAddress, "totalSupply", [], [])
-        const lpTokenSupplyBytes = await provider.call(lpTokenSupplyQuery)
+        
+        const lpTokenSupplyBytes = queryResults[5];
         const lpTokenSupply = abiCoder.decode(["uint"], lpTokenSupplyBytes)[0]
 
-        const userLpTokenBalanceQuery = composeQuery(ibcContractAddress, "balanceOf", ["address"], [wallet.accounts[0].address])
-        const userLpTokenBalanceBytes = await provider.call(userLpTokenBalanceQuery)
+        
+        const userLpTokenBalanceBytes = queryResults[6];
         const userLpTokenBalance = abiCoder.decode(["uint"], userLpTokenBalanceBytes)[0]
 
         // lp approval state
-        const userLpTokenAllowanceQuery = composeQuery(ibcContractAddress, "allowance", ["address", "address"], [wallet.accounts[0].address, ibcContractAddress])
-        const userLpTokenAllowanceBytes = await provider.call(userLpTokenAllowanceQuery)
+        
+        const userLpTokenAllowanceBytes = queryResults[7];
         const userLpTokenAllowance = abiCoder.decode(["uint"], userLpTokenAllowanceBytes)[0]
 
         // fetch rewards data
-        const userClaimableRewardsQuery = composeQuery(ibcContractAddress, "rewardOf", ["address"], [wallet.accounts[0].address])
-        const userClaimableRewardsBytes = await provider.call(userClaimableRewardsQuery)
+        
+        const userClaimableRewardsBytes = queryResults[8];
         const userClaimableRewards = abiCoder.decode(["uint256", "uint256", "uint256", "uint256"], userClaimableRewardsBytes)
 
         // fetch staking balance
-        const userStakingBalanceQuery = composeQuery(ibcContractAddress, "stakingBalanceOf", ["address"], [wallet.accounts[0].address])
-        const userStakingBalanceBytes = await provider.call(userStakingBalanceQuery)
+        
+        const userStakingBalanceBytes = queryResults[9];
         const userStakingBalance = abiCoder.decode(["uint256"], userStakingBalanceBytes)[0]
+
+
+        const inverseTokenDecimalsQuery = composeQuery(inverseTokenAddress, "decimals", [], [])
+        const userInverseTokenBalanceQuery = composeQuery(inverseTokenAddress, "balanceOf", ["address"], [wallet.accounts[0].address])
+        const userInverseTokenAllowanceQuery = composeQuery(inverseTokenAddress, "allowance", ["address", "address"], [wallet.accounts[0].address, ibcContractAddress])
+        const tokenQueryResults = await Promise.all([
+          provider.call(inverseTokenDecimalsQuery),
+          provider.call(userInverseTokenBalanceQuery),
+          provider.call(userInverseTokenAllowanceQuery)
+        ]);
+
+        // ibc token info        
+        const inverseTokenDecimalsBytes = tokenQueryResults[0];
+        const inverseTokenDecimals = abiCoder.decode(["uint"], inverseTokenDecimalsBytes)[0]
+
+        
+        const userInverseTokenBalanceBytes = tokenQueryResults[1];
+        const userInverseTokenBalance = abiCoder.decode(["uint"], userInverseTokenBalanceBytes)[0]
+
+        // ibc approval state        
+        const userInverseTokenAllowanceBytes = tokenQueryResults[2];
+        const userInverseTokenAllowance = abiCoder.decode(["uint"], userInverseTokenAllowanceBytes)[0]
 
         setDashboardDataSet({
           userEthBalance: ethBalance.toString(),
@@ -409,7 +507,7 @@ export function Dashboard( props: dashboardProps ){
                         {
                           selectedNavItem === "claim" &&
                           <>
-                            <ClaimLpRewards dashboardDataSet={dashboardDataSet}/>
+                            <ClaimLpRewards dashboardDataSet={dashboardDataSet} closeParentDialog={handleModalClose}/>
                           </>
                         }
                       </ModalBody>


### PR DESCRIPTION
1. Right align claim reward text
2. Add resize width/height check to avoid unnecessary redraw
3. Close claim dialog if claim successfully(If claim success, the left reward will be zero, user won't be able to claim again, then feels no need to keep the dialog open)
4. Disable claim/stake/unstake button before transaction processed
5. Send batch requests when query wallet infor(otherwise UI not updated for a quite long time on slow network)
6. Update contract address to latest contract address