### PR TITLE
251 fix linting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import {
   Box,
 } from "@chakra-ui/react"
 
-import { init, useConnectWallet } from '@web3-onboard/react';
+import { init } from '@web3-onboard/react';
 import injectedModule from '@web3-onboard/injected-wallets';
 import { ethers } from 'ethers'
 import { Route, Routes } from "react-router-dom";
@@ -13,7 +13,6 @@ import { contracts, } from "./config/contracts";
 import { useState } from "react";
 import { Analytics } from '@vercel/analytics/react';
 import { providerPollingIntervalMilliSeconds } from "./config/constants";
-import { CgNametag } from "react-icons/cg";
 
 const injected = injectedModule();
 

--- a/src/components/ConnectWallet.tsx
+++ b/src/components/ConnectWallet.tsx
@@ -14,7 +14,7 @@ interface Account {
 
 export default function ConnectWallet() {
   const [{ wallet, connecting }, connect, disconnect] = useConnectWallet()
-  const [ethersProvider, setProvider] = useState<ethers.providers.Web3Provider | null>()
+  const [, setProvider] = useState<ethers.providers.Web3Provider | null>()
   const [account, setAccount] = useState<Account | null>(null)
 
   useEffect(() => {

--- a/src/components/ConnectWallet.tsx
+++ b/src/components/ConnectWallet.tsx
@@ -37,8 +37,6 @@ export default function ConnectWallet() {
     }
   }, [wallet])
 
-  const bal = wallet?.accounts[0]?.balance
-
   if(wallet?.provider && account) {
     return (
         <Button

--- a/src/components/bondingCurveChart/bonding_curve_chart.tsx
+++ b/src/components/bondingCurveChart/bonding_curve_chart.tsx
@@ -293,11 +293,10 @@ export default function BondingCurveChart(props: IProps) {
         }      
     }
     function drawBondingCurve(curChartParam: IChartParam, curChartState: IChartState, refreshCurve: boolean, refreshArea: boolean, refreshNewCurve: boolean) {
-        let currentCurvePainted = false, liquidityAreaPainted = false, newCurvePainted = false;
+        let liquidityAreaPainted = false
         if(curChartParam){
             if (refreshCurve) {
                 drawCurve(curChartState, curChartParam.curveParameter, 'line');
-                currentCurvePainted = true;
                 
             }
     
@@ -305,7 +304,6 @@ export default function BondingCurveChart(props: IProps) {
                 let newChartParam = getProperParameter(curChartState, curChartParam);                
                 drawCurve(curChartState, newChartParam.curveParameter, 'target-line');
                 drawDot(curChartState, newChartParam.curveParameter, newChartParam.currentSupply, 'dot-target');
-                newCurvePainted = true;                
             }
     
             if(refreshArea){
@@ -466,51 +464,51 @@ export default function BondingCurveChart(props: IProps) {
         }
     }
 
-    function handleMouseOver(event: any) {
-        if (chartState && chartState.chart) {
-            const chart = chartState?.chart;
-            const xScale = chartState?.xScale;
+    // function handleMouseOver(event: any) {
+    //     if (chartState && chartState.chart) {
+    //         const chart = chartState?.chart;
+    //         const xScale = chartState?.xScale;
 
-            const [x, y] = d3.pointer(event);
-            const value = xScale.invert(x).toFixed(2);
+    //         const [x, y] = d3.pointer(event);
+    //         const value = xScale.invert(x).toFixed(2);
 
-            const tooltipGroup = chart.append('g')
-                .attr('class', 'tooltip-group')
-                .style('pointer-events', 'none');
+    //         const tooltipGroup = chart.append('g')
+    //             .attr('class', 'tooltip-group')
+    //             .style('pointer-events', 'none');
 
-            tooltipGroup.append('rect')
-                .attr('class', 'tooltip-bg')
-                .attr('x', x - 30)
-                .attr('y', y - 60)
-                .attr('width', 100)
-                .attr('height', 20)
+    //         tooltipGroup.append('rect')
+    //             .attr('class', 'tooltip-bg')
+    //             .attr('x', x - 30)
+    //             .attr('y', y - 60)
+    //             .attr('width', 100)
+    //             .attr('height', 20)
 
-            // TODO: What to show on tooltip?
-            // tooltipGroup.append('text')
-            //     .attr('class', 'tooltip-text')
-            //     .attr('x', x - 25)
-            //     .attr('y', y - 45)
-            //     .attr('text-anchor', 'left')
-            //     .style('font-size', '10px')
-            //     .style('white-space', 'pre')
-            //     .text(`Supply   : ${param.currentSupply} -> ${param.targetSupply}`);
-            // tooltipGroup.append('text')
-            //     .attr('class', 'tooltip-text')
-            //     .attr('x', x - 25)
-            //     .attr('y', y - 30)
-            //     .attr('text-anchor', 'left')
-            //     .style('font-size', '10px')
-            //     .style('white-space', 'pre')
-            //     .text("Reserve : 178.56 -> 192.39");
-        }
-    }
+    //         // TODO: What to show on tooltip?
+    //         // tooltipGroup.append('text')
+    //         //     .attr('class', 'tooltip-text')
+    //         //     .attr('x', x - 25)
+    //         //     .attr('y', y - 45)
+    //         //     .attr('text-anchor', 'left')
+    //         //     .style('font-size', '10px')
+    //         //     .style('white-space', 'pre')
+    //         //     .text(`Supply   : ${param.currentSupply} -> ${param.targetSupply}`);
+    //         // tooltipGroup.append('text')
+    //         //     .attr('class', 'tooltip-text')
+    //         //     .attr('x', x - 25)
+    //         //     .attr('y', y - 30)
+    //         //     .attr('text-anchor', 'left')
+    //         //     .style('font-size', '10px')
+    //         //     .style('white-space', 'pre')
+    //         //     .text("Reserve : 178.56 -> 192.39");
+    //     }
+    // }
 
-    function handleMouseOut() {
-        if (chartState && chartState.chart) {
-            const chart = chartState?.chart;
-            chart.select('.tooltip-group').remove();
-        }
-    }
+    // function handleMouseOut() {
+    //     if (chartState && chartState.chart) {
+    //         const chart = chartState?.chart;
+    //         chart.select('.tooltip-group').remove();
+    //     }
+    // }
 
     function drawArea(curChartState: IChartState, param: IChartParam, supplyRange: number[]) {
 

--- a/src/components/bondingCurveChart/bonding_curve_chart.tsx
+++ b/src/components/bondingCurveChart/bonding_curve_chart.tsx
@@ -386,7 +386,6 @@ export default function BondingCurveChart(props: IProps) {
             const chart = curChartState?.chart;
             const xScale = curChartState?.xScale;
             const yScale = curChartState?.yScale;
-            const supplyRange = curChartState?.supplyRange;
 
             const parameterK = param.parameterK;
             const parameterM = param.parameterM;

--- a/src/components/bondingCurveChart/bonding_curve_chart.tsx
+++ b/src/components/bondingCurveChart/bonding_curve_chart.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import * as d3 from 'd3';
 import * as _ from "lodash";
-import { useCallback, useEffect, useState, useRef } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { curveUtilization } from '../../config/constants';
-import { RiNewspaperLine } from 'react-icons/ri';
 
 interface ICurveParam {
     parameterK: number;
@@ -59,9 +58,6 @@ export default function BondingCurveChart(props: IProps) {
     const MIN_SUPPLY_FACTOE = 0.2;
     const GRID_LINE_COUNT = 7;
 
-    const MAX_PARAMETER_K = [0.55, 0.9];
-    const MIN_PARAMETER_K = [0.35, 0.45];
-
     useEffect(() => {
 
         if (props && props.chartParam && props.chartParam.currentSupply) {
@@ -71,9 +67,9 @@ export default function BondingCurveChart(props: IProps) {
                     return;
                 }
     
-                refreshArea = chartParam.targetSupplyChange != props.chartParam.targetSupplyChange;
+                refreshArea = chartParam.targetSupplyChange !== props.chartParam.targetSupplyChange;
     
-                refreshNewCurve = chartParam.targetLiquidityChange != props.chartParam.targetLiquidityChange;
+                refreshNewCurve = chartParam.targetLiquidityChange !== props.chartParam.targetLiquidityChange;
             }else{
                 forceRefresh = true;
             }
@@ -86,7 +82,7 @@ export default function BondingCurveChart(props: IProps) {
                 height: 0
             }
             const resizeObserver = new ResizeObserver(entries => {                
-                if(entries[0].contentRect.width != previousSize.width || entries[0].contentRect.height != previousSize.height){
+                if(entries[0].contentRect.width !== previousSize.width || entries[0].contentRect.height !== previousSize.height){
                     previousSize.width = entries[0].contentRect.width;
                     previousSize.height = entries[0].contentRect.height;
                     if (curChartParam && curChartParam.currentSupply) {
@@ -234,7 +230,6 @@ export default function BondingCurveChart(props: IProps) {
                 setInitialized(true);
             } else {
                 getRectRange();
-                let supplyRange = chartState.supplyRange;
                 let curChartState = chartState;
 
                 curChartState = updateChartData(curChartParam);
@@ -324,10 +319,6 @@ export default function BondingCurveChart(props: IProps) {
                 drawDot(curChartState, curChartParam.curveParameter, curChartParam.currentSupply, 'dot-from');
             }
         }
-    }
-
-    function inDataRange(dataRange: number[], data: number) {
-        return data >= dataRange[0] && data <= dataRange[dataRange.length - 1];
     }
 
     function drawLiquidityArea(curChartParam: IChartParam, curChartState: IChartState) {

--- a/src/components/dashboard/add_ibc.tsx
+++ b/src/components/dashboard/add_ibc.tsx
@@ -1,7 +1,6 @@
-import { useCallback, useState } from 'react'
+import { useCallback } from 'react'
 import { useConnectWallet } from '@web3-onboard/react'
 import { Box, Image } from '@chakra-ui/react'
-import { contracts } from '../../config/contracts'
 import { isAbleToSendTransaction } from '../../config/validation'
 import { curves } from '../../config/curves'
 import * as _ from "lodash";

--- a/src/components/dashboard/add_liquidity.tsx
+++ b/src/components/dashboard/add_liquidity.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { ethers, BigNumber } from 'ethers'
 import {
 	Box,
@@ -58,16 +58,12 @@ export default function AddLiquidity(props: mintProps) {
 		'bondingCurveParams' in dashboardDataSet
 			? dashboardDataSet.bondingCurveParams
 			: {}
-	const inverseTokenDecimals = BigNumber.from(
-		'inverseTokenDecimals' in dashboardDataSet
-			? dashboardDataSet.inverseTokenDecimals
-			: '0'
-	)
+
   const reserveTokenDecimals = "reserveTokenDecimals" in dashboardDataSet ? dashboardDataSet.reserveTokenDecimals.toNumber() : 0; 
 	const lpTokenSupply = BigNumber.from(
 		'lpTokenSupply' in dashboardDataSet ? dashboardDataSet.lpTokenSupply : '0'
 	)
-	const userBalance = dashboardDataSet.reserveTokenSymbol == "ETH" ? BigNumber.from(
+	const userBalance = dashboardDataSet.reserveTokenSymbol === "ETH" ? BigNumber.from(
 		'userEthBalance' in dashboardDataSet ? dashboardDataSet.userEthBalance : '0'
 	) : BigNumber.from('userReserveTokenBalance' in dashboardDataSet ? dashboardDataSet.userReserveTokenBalance : '0')
 	const userLpTokenBalance = bignumber(

--- a/src/components/dashboard/asset_holding.tsx
+++ b/src/components/dashboard/asset_holding.tsx
@@ -116,7 +116,7 @@ export default function AssetHolding(props: assetListProps) {
                                                         <Box boxSize='28px' mr='4'>
                                                             <Image src={balance.image} alt={balance.ibAsset} />
                                                         </Box>
-                                                        <Link fontWeight={'700'} href={window.location.origin + "\/#\/" + balance.reserveAddress} isExternal>
+                                                        <Link fontWeight={'700'} href={window.location.origin + "/#/" + balance.reserveAddress} isExternal>
                                                             {balance.ibAsset}
                                                         </Link>
                                                     </Stack>
@@ -134,7 +134,7 @@ export default function AssetHolding(props: assetListProps) {
                                                     <Box boxSize='28px' mr='4'>
                                                         <Image src={balance.image} alt={balance.ibAsset} />
                                                     </Box>
-                                                    <Link fontWeight={'700'} href={window.location.origin + "\/#\/" + balance.reserveAddress} isExternal>
+                                                    <Link fontWeight={'700'} href={window.location.origin + "/#/" + balance.reserveAddress} isExternal>
                                                         {balance.ibAsset}
                                                     </Link>
                                                 </Stack>

--- a/src/components/dashboard/asset_holding.tsx
+++ b/src/components/dashboard/asset_holding.tsx
@@ -39,8 +39,8 @@ type holdingBalance = {
 }
 
 export default function AssetHolding(props: assetListProps) {
-    const [{ wallet, }] = useConnectWallet()
-    const [provider, setProvider] =
+    const [{ wallet }] = useConnectWallet()
+    const [, setProvider] =
         useState<ethers.providers.Web3Provider | null>()
     const [holdingBalance, setHoldingBalance] = useState<holdingBalance[]>();
 

--- a/src/components/dashboard/asset_list.tsx
+++ b/src/components/dashboard/asset_list.tsx
@@ -89,7 +89,7 @@ export default function AssetList(props: assetListProps) {
             for (let i = 0; i < loadCnt; i++) {
                 if (multicallResults[i][0]) {
                     const curveAddress = abiCoder.decode(["address"], multicallResults[i][1])[0];
-                    if (curveAddress != ethers.constants.AddressZero) {
+                    if (curveAddress !== ethers.constants.AddressZero) {
                         curveAddressList.push(curveAddress);
                     }
                 }
@@ -153,7 +153,7 @@ export default function AssetList(props: assetListProps) {
 
                 const reserveTokenSymbolBytes = multicallResults[i * 3 + 1][0] ? multicallResults[i * 3 + 1][1] : [""];
                 let reserveTokenSymbol = abiCoder.decode(["string"], reserveTokenSymbolBytes)[0];
-                if (reserveTokenSymbol == 'WETH') {
+                if (reserveTokenSymbol === 'WETH') {
                     reserveTokenSymbol = 'ETH';
                 }
 
@@ -184,7 +184,7 @@ export default function AssetList(props: assetListProps) {
 
             const curvesMissingInfo = _.differenceBy(curveMetadataList, curveList || [], 'curveAddress');
 
-            if (curvesMissingInfo.length == 0) {
+            if (curvesMissingInfo.length === 0) {
                 return;
             }
             setIsLoading(true);
@@ -394,7 +394,7 @@ export default function AssetList(props: assetListProps) {
             setFilteredCurveList(filterResult);
             if (filterResult.length === 0) {
                 filterResult = await fectchCurveInfo(search);
-                if(filterResult.length == 1){
+                if(filterResult.length === 1){
                     let curveMeta = _.pick(filterResult[0], [
                         'curveAddress',
                         'reserveSymbol',
@@ -486,7 +486,7 @@ export default function AssetList(props: assetListProps) {
                                                             <Box boxSize='28px' mr='4'>
                                                                 <Image src={item.image} alt={item.ibAsset} />
                                                             </Box>
-                                                            <Link fontWeight={'700'} href={window.location.origin + "\/#\/" + item.reserveAddress} isExternal>
+                                                            <Link fontWeight={'700'} href={window.location.origin + "/#/" + item.reserveAddress} isExternal>
                                                                 {item.ibAsset}
                                                             </Link>
                                                         </Stack>
@@ -498,7 +498,7 @@ export default function AssetList(props: assetListProps) {
                                                         <Box boxSize='28px' mr='4'>
                                                             <Image src={item.image} alt={item.ibAsset} />
                                                         </Box>
-                                                        <Link fontWeight={'700'} href={window.location.origin + "\/#\/" + item.reserveAddress} isExternal>
+                                                        <Link fontWeight={'700'} href={window.location.origin + "/#/" + item.reserveAddress} isExternal>
                                                             {item.ibAsset}
                                                         </Link>
                                                     </Stack>

--- a/src/components/dashboard/burn_tokens.tsx
+++ b/src/components/dashboard/burn_tokens.tsx
@@ -39,7 +39,7 @@ import { BiLinkExternal } from 'react-icons/bi'
 import { error_message } from '../../config/error'
 import { isAbleToSendTransaction } from '../../config/validation'
 import { formatBalanceNumber, formatReceiveNumber, format, parse, sanitizeNumberInput } from '../../util/display_formatting'
-import { computeSquareRoot, divBnJs, formatUnitsBnJs, mulPercent, parseUnitsBnJs } from '../../util/ethers_utils'
+import { computeSquareRoot, formatUnitsBnJs, mulPercent, parseUnitsBnJs } from '../../util/ethers_utils'
 import { WalletState } from '@web3-onboard/core'
 
 type mintProps = {
@@ -78,7 +78,7 @@ export default function BurnTokens(props: mintProps) {
 			? dashboardDataSet.inverseTokenDecimals
 			: '0'
 	)
-	const userBalance = dashboardDataSet.reserveTokenSymbol == "ETH" ? BigNumber.from(
+	const userBalance = dashboardDataSet.reserveTokenSymbol === "ETH" ? BigNumber.from(
 		'userEthBalance' in dashboardDataSet ? dashboardDataSet.userEthBalance : '0'
 	) : BigNumber.from('userReserveTokenBalance' in dashboardDataSet ? dashboardDataSet.userReserveTokenBalance : '0')
 	const userIbcBalance ='userIbcTokenBalance' in dashboardDataSet
@@ -347,10 +347,6 @@ export default function BurnTokens(props: mintProps) {
 		const currentInverseTokenSupplyBig = BigNumber.from(bondingCurveParams.inverseTokenSupply)
 		const currentInverseTokenSupply = Number(ethers.utils.formatUnits(bondingCurveParams.inverseTokenSupply, inverseTokenDecimals.toString()))
 		const k = 1 - curveUtilization
-
-		const mBig = BigNumber.from(bondingCurveParams.currentTokenPrice).mul(
-			computeSquareRoot(currentInverseTokenSupplyBig)
-		)
 
 		const m = Number(ethers.utils.formatUnits(bondingCurveParams.currentTokenPrice, defaultDecimals)) 
 		* 

--- a/src/components/dashboard/claim_lp_rewards.tsx
+++ b/src/components/dashboard/claim_lp_rewards.tsx
@@ -33,7 +33,6 @@ export default function ClaimLpRewards(props: mintProps) {
   const userClaimableStakingReserveRewards = BigNumber.from("userClaimableStakingReserveRewards" in dashboardDataSet ? dashboardDataSet.userClaimableStakingReserveRewards : '0')
 
   const inverseTokenDecimals = BigNumber.from("lpTokenDecimals" in dashboardDataSet ? dashboardDataSet.lpTokenDecimals : '0');
-  const totalStakingBalance = 'totalStakingBalance' in dashboardDataSet ? dashboardDataSet.totalStakingBalance : '0'
   const forceUpdate = dashboardDataSet.forceUpdate;
   const [isProcessing, setIsProcessing] = useState(false);
 

--- a/src/components/dashboard/create_ibasset.tsx
+++ b/src/components/dashboard/create_ibasset.tsx
@@ -5,11 +5,9 @@ import {
 	Box,
 	Button,
 	Icon,
-	Input,
 	Link,
 	NumberInput,
 	NumberInputField,
-	Spacer,
 	Stack,
 	Text,
 } from '@chakra-ui/react'
@@ -18,17 +16,14 @@ import {
 	concat,
 	defaultAbiCoder,
 	hexlify,
-	parseEther,
 	formatUnits,
 	parseUnits,
-	formatEther,
 	solidityKeccak256,
 } from 'ethers/lib/utils'
 import { contracts } from '../../config/contracts'
 import { colors } from '../../config/style'
 import {
 	explorerUrl,
-	commandTypes
 } from '../../config/constants'
 import { CgArrowDownR } from 'react-icons/cg'
 
@@ -37,7 +32,7 @@ import { Toast } from '../toast'
 import { BiLinkExternal } from 'react-icons/bi'
 import { error_message } from '../../config/error'
 import { isAbleToSendTransaction } from '../../config/validation'
-import { formatBalanceNumber, formatNumber, formatReceiveNumber, format, parse, sanitizeNumberInput } from '../../util/display_formatting'
+import { formatBalanceNumber, formatNumber, sanitizeNumberInput } from '../../util/display_formatting'
 import { composeMulticallQuery, composeQuery } from '../../util/ethers_utils'
 
 type mintProps = {
@@ -46,7 +41,7 @@ type mintProps = {
 }
 
 export default function CreateIBAsset(props: mintProps) {
-	const [{ wallet, connecting }] = useConnectWallet()
+	const [{ wallet }] = useConnectWallet()
 	const [provider, setProvider] =
 		useState<ethers.providers.Web3Provider | null>()
 	const [amount, setAmount] = useState<number>()

--- a/src/components/dashboard/create_ibasset_list.tsx
+++ b/src/components/dashboard/create_ibasset_list.tsx
@@ -121,14 +121,14 @@ export default function CreateIBAssetList(props: assetListProps) {
         if (search.startsWith("0x")) {
             setFilteredCurveList(_.filter(curveList, curve => curve.reserveAddress.toLowerCase() === search.toLowerCase()));
 
-            if (search.length == 42) {
+            if (search.length === 42) {
                 const provider = getProvider();
                 if (provider) {
                     try {
                         let query = composeQuery(ibcFactoryAddress, "getCurve", ["address"], [search])
                         let callResultBytes = await provider.call(query)
                         let callResult = defaultAbiCoder.decode(["address"], callResultBytes)[0]
-                        if (callResult == ethers.constants.AddressZero) {
+                        if (callResult === ethers.constants.AddressZero) {
                             reserveAddress = search;
                         } else {
                             let curveInfo = {
@@ -209,7 +209,7 @@ export default function CreateIBAssetList(props: assetListProps) {
                                                         <Box boxSize='28px' mr='4'>
                                                             <Image src={item.image} alt={item.reserveSymbol} />
                                                         </Box>
-                                                        <Link fontWeight={'700'} href={window.location.origin + "\/#\/" + item.reserveAddress} isExternal>
+                                                        <Link fontWeight={'700'} href={window.location.origin + "/#/" + item.reserveAddress} isExternal>
                                                             {item.reserveSymbol}
                                                         </Link>
                                                     </Stack>
@@ -225,7 +225,7 @@ export default function CreateIBAssetList(props: assetListProps) {
                                                     <Box boxSize='28px' mr='4'>
                                                         <Image src={item.image} alt={item.reserveSymbol} />
                                                     </Box>
-                                                    <Link fontWeight={'700'} href={window.location.origin + "\/#\/" + item.reserveAddress} isExternal>
+                                                    <Link fontWeight={'700'} href={window.location.origin + "/#/" + item.reserveAddress} isExternal>
                                                         {item.reserveSymbol}
                                                     </Link>
                                                 </Stack>

--- a/src/components/dashboard/curve_manager.ts
+++ b/src/components/dashboard/curve_manager.ts
@@ -43,7 +43,7 @@ export class CurveManager {
 
         return curvesWithPreload.map(curve => ({
             ...curve,   
-            verified: curve.icon != '' && curve.icon !== "ib_asset_logo.svg"
+            verified: curve.icon !== '' && curve.icon !== "ib_asset_logo.svg"
         }));
     }
 

--- a/src/components/dashboard/lp_position.tsx
+++ b/src/components/dashboard/lp_position.tsx
@@ -1,21 +1,17 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useConnectWallet } from '@web3-onboard/react'
-import { ethers, BigNumber } from 'ethers'
-import { Box, Button, Divider, Icon, Input, Link, Stack, Text, Image, Tooltip } from '@chakra-ui/react'
+import { ethers } from 'ethers'
+import { Box,Link, Stack, Image, Tooltip } from '@chakra-ui/react'
 
 import {
     Table,
-    Thead,
     Tbody,
-    Tfoot,
     Tr,
-    Th,
     Td,
     TableContainer,
 } from '@chakra-ui/react'
 import * as _ from "lodash";
 import { composeMulticallQuery, composeQuery } from '../../util/ethers_utils'
-import { curves } from '../../config/curves'
 import { contracts } from '../../config/contracts'
 
 type CurveInfo = {
@@ -112,7 +108,7 @@ export default function LpPosition(props: assetListProps) {
                                                         <Box boxSize='28px' mr='4'>
                                                             <Image src={position.image} alt={position.reserveAddress} />
                                                         </Box>
-                                                        <Link fontWeight={'700'} href={window.location.origin + "\/#\/" + position.reserveAddress} isExternal>
+                                                        <Link fontWeight={'700'} href={window.location.origin + "/#/" + position.reserveAddress} isExternal>
                                                             {position.ibAsset}
                                                         </Link>
                                                     </Stack>
@@ -129,7 +125,7 @@ export default function LpPosition(props: assetListProps) {
                                                         <Box boxSize='28px' mr='4'>
                                                             <Image src={position.image} alt={position.reserveAddress} />
                                                         </Box>
-                                                        <Link fontWeight={'700'} href={window.location.origin + "\/#\/" + position.reserveAddress} isExternal>
+                                                        <Link fontWeight={'700'} href={window.location.origin + "/#/" + position.reserveAddress} isExternal>
                                                             {position.ibAsset}
                                                         </Link>
                                                     </Stack>

--- a/src/components/dashboard/lp_position.tsx
+++ b/src/components/dashboard/lp_position.tsx
@@ -39,7 +39,7 @@ type lpPosition = {
 
 export default function LpPosition(props: assetListProps) {
     const [{ wallet, }] = useConnectWallet()
-    const [provider, setProvider] =
+    const [, setProvider] =
         useState<ethers.providers.Web3Provider | null>()
     const [lpPosition, setLpPosition] = useState<lpPosition[]>();
 

--- a/src/components/dashboard/mint_tokens.tsx
+++ b/src/components/dashboard/mint_tokens.tsx
@@ -69,7 +69,7 @@ export default function MintTokens(props: mintProps) {
 			: '0'
 	)
 	// todo: special case - use the eth balance for weth
-	const userBalance = dashboardDataSet.reserveTokenSymbol == "ETH" ? BigNumber.from(
+	const userBalance = dashboardDataSet.reserveTokenSymbol === "ETH" ? BigNumber.from(
 		'userEthBalance' in dashboardDataSet ? dashboardDataSet.userEthBalance : '0'
 	) : BigNumber.from('userReserveTokenBalance' in dashboardDataSet ? dashboardDataSet.userReserveTokenBalance : '0')
 	const userIbcBalance =

--- a/src/components/dashboard/remove_liquidity.tsx
+++ b/src/components/dashboard/remove_liquidity.tsx
@@ -45,10 +45,10 @@ type mintProps = {
 }
 
 export default function RemoveLiquidity(props: mintProps) {
-	const [amount, setAmount] = useState<number>()
+	const [amount] = useState<number>()
 	const [ibcContractAddress] = useState<string>(contracts.default.ibcETHCurveContract)
 	const [ibcRouterAddress] = useState<string>(contracts.default.ibcRouterContract)
-	const { dashboardDataSet, parentSetters, wallet } = props
+	const { dashboardDataSet, wallet } = props
 	const [maxSlippage, setMaxSlippage] = useState<number>(maxSlippagePercent)
 
 	const userInverseTokenAllowance = BigNumber.from(
@@ -65,10 +65,7 @@ export default function RemoveLiquidity(props: mintProps) {
 			? dashboardDataSet.lpTokenDecimals
 			: '0'
 	)
-  const reserveTokenDecimals = "reserveTokenDecimals" in dashboardDataSet ? dashboardDataSet.reserveTokenDecimals : BigNumber.from('0'); 
-	const userBalance = BigNumber.from(
-		'userEthBalance' in dashboardDataSet ? dashboardDataSet.userEthBalance : '0'
-	) 
+
 	const userLpTokenBalance = 'userLpTokenBalance' in dashboardDataSet ? dashboardDataSet.userLpTokenBalance : '0'
 	const userIbcTokenBalance = 'userIbcTokenBalance' in dashboardDataSet ? BigNumber.from(dashboardDataSet.userIbcTokenBalance) : BigNumber.from(0)
 
@@ -84,9 +81,6 @@ export default function RemoveLiquidity(props: mintProps) {
 
 	const userLpRedeemableReserves = 'userLpRedeemableReserves' in dashboardDataSet ? dashboardDataSet.userLpRedeemableReserves : '0'
 	
-	const lpTokenSupply = BigNumber.from(
-		'lpTokenSupply' in dashboardDataSet ? dashboardDataSet.lpTokenSupply : '0'
-	)
 	const totalFeePercent =
 		'fees' in dashboardDataSet
 			? Object.keys(dashboardDataSet.fees).reduce(

--- a/src/components/radio_card.tsx
+++ b/src/components/radio_card.tsx
@@ -1,5 +1,4 @@
 import { Box, useRadio } from "@chakra-ui/react"
-import { colors } from "../config/style"
 
 export function RadioCard(props: any) {
     const { getInputProps, getCheckboxProps } = useRadio(props)

--- a/src/config/contracts.ts
+++ b/src/config/contracts.ts
@@ -1,5 +1,3 @@
-import { ethers } from 'ethers'
-
 export const contracts = {
   default:{
     wethAddress: process.env.REACT_APP_WETH_TOKEN ?? "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -34,7 +34,7 @@ import AssetHolding from "../components/dashboard/asset_holding";
 import LpPosition from "../components/dashboard/lp_position";
 import CreateIBAsset from "../components/dashboard/create_ibasset";
 import CreateIBAssetList from "../components/dashboard/create_ibasset_list";
-import { Navigate, useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { curves } from "../config/curves";
 import { cacheToLocal, fetchFromLocal, getStorageKey } from "../util/caching";
 
@@ -128,7 +128,7 @@ export function Dashboard( props: dashboardProps ){
 
   const [selectedNavItem, setSelectedNavItem] = useState<string>(navOptions[!isExplorePage && !isTermsPage ? 1 : 0].value);
   const [headerTitle, setHeaderTitle] = useState<string>(navOptions[0].displayText.toUpperCase());
-  const [{ wallet,  }] = useConnectWallet()
+  const [{ wallet }] = useConnectWallet()
   const [ibcContractAddress, setIbcContractAddress] = useState<string>()
   const [ibcAdminAddress, ] = useState<string>(contracts.default.ibcAdminContract)
   const [ibcRouterAddress, ] = useState<string>(contracts.default.ibcRouterContract)

--- a/src/util/display_formatting.ts
+++ b/src/util/display_formatting.ts
@@ -121,7 +121,7 @@ export function logBigInt(number: String){
 }
 
 export const format = (val: any) => val + `%`
-export const parse = (val: any) => val.replace(/^\%/, '')
+export const parse = (val: any) => val.replace(/^%/, '')
 export function sanitizeNumberInput(input: any){
   const sanitizedValue = input
   .replace(/[-+e]/g, "")

--- a/src/util/ethers_utils.ts
+++ b/src/util/ethers_utils.ts
@@ -1,5 +1,5 @@
-import { arrayify, concat, defaultAbiCoder, hexlify, Interface, parseEther, solidityKeccak256 } from 'ethers/lib/utils'
-import { bigOne, multicallContinueOnErrorFlag } from '../config/constants'
+import { arrayify, concat, defaultAbiCoder, hexlify, solidityKeccak256 } from 'ethers/lib/utils'
+import { multicallContinueOnErrorFlag } from '../config/constants'
 import { BigNumber } from "ethers";
 import { BigNumber as bignumber } from "bignumber.js"
 


### PR DESCRIPTION
Fix lint warnings except useCallback useEffect dependency warnings. 

1. Remove non used variables
2. Use strict equality
3. Remove unnecessary regex syntax
4. Comment out non using code block

useCallback useEffect dependency warnings can be fixed while refactoring hooks. would like to make a different issue for that. Thanks!
